### PR TITLE
deps: updated build image to go 1.19.6

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -76,8 +76,8 @@ RUN set -ex \
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.16.7 && \
-    GO_HASH=7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04 && \
+RUN GO_VERSION=1.19.6 && \
+    GO_HASH=e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -58,7 +58,7 @@ GO_LDFLAGS += -s -w
 endif
 
 # supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.16|1.17
+GO_SUPPORTED_VERSIONS ?= 1.16|1.17|1.18|1.19
 
 # set GOOS and GOARCH
 GOOS := $(OS)
@@ -210,7 +210,7 @@ endif
 
 # we use a consistent version of gofmt even while running different go compilers.
 # see https://github.com/golang/go/issues/26397 for more details
-GOFMT_VERSION ?= 1.16.6
+GOFMT_VERSION ?= 1.19.6
 GOFMT_DOWNLOAD_URL ?= https://dl.google.com/go/go$(GOFMT_VERSION).$(HOSTOS)-$(HOSTARCH).tar.gz
 ifneq ($(findstring $(GOFMT_VERSION),$(GO_VERSION)),)
 GOFMT := $(shell which gofmt)


### PR DESCRIPTION
- Updated the build image go version to 1.19, which will have support until 1.21 is released (in ~6mo)